### PR TITLE
Update setup-kubernetes-goat.sh

### DIFF
--- a/setup-kubernetes-goat.sh
+++ b/setup-kubernetes-goat.sh
@@ -3,6 +3,11 @@
 # This program has been created as part of Kuberentes Goat
 # Kuberentes Goat setup and manage vulnerable infrastrcuture 
 
+
+#Starting minikube
+echo "Starting minikube..."
+minikube start
+sleep 25
 # Checking kubectl setup
 kubectl version --short > /dev/null 2>&1 
 if [ $? -eq 0 ];


### PR DESCRIPTION
Updated with minikube start to support if the user has missed to start it manually, if he didnt start  the following line will trigger the error mentioned in even if the kubectl is installed.
```bash
kubectl version --short > /dev/null 2>&1
``` 
Error
```bash
"Error: Could not find kubectl or an other error happend, please check kubectl setup."
```