### PR TITLE
Adding kind support

### DIFF
--- a/kind-setup/kind-cluster-setup.yaml
+++ b/kind-setup/kind-cluster-setup.yaml
@@ -1,0 +1,7 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes: 
+  - role: control-plane
+    extraMounts:
+      - hostPath: /var/run/docker.sock
+        containerPath: /var/run/docker.sock

--- a/kind-setup/setup-kind-cluster-and-goat.sh
+++ b/kind-setup/setup-kind-cluster-and-goat.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Author: Mauricio Cano
+# This file has been created to contribute to the development of the Kubernetes GOAT
+
+# Setup working dir
+cd "${0%/*}"
+
+# Check that kind is installed
+kind version > /dev/null 2>&1 
+if [ $? -eq 0 ];
+then
+    echo "Kind is installed, all good"
+else 
+    echo "Please install Kind to use this setup file"
+    exit;
+fi
+
+# Check that docker is installed in the host
+docker version --format '{{.Server.Version}}' > /dev/null 2>&1 
+if [ $? -eq 0 ];
+then
+    echo "Docker is installed, all good"
+else 
+    echo "Please install Docker to use this setup file"
+    exit;
+fi
+
+# Setup cluster using extraMounts to expose the docker socket from the host
+kind create cluster --config kind-cluster-setup.yaml --name kubernetes-goat-cluster
+
+# Move to the root dir
+cd ..
+
+# Setup GOAT exposing host Docker socket:
+sed 's/scenarios\/health-check\/deployment.yaml/scenarios\/health-check\/deployment-kind.yaml/' setup-kubernetes-goat.sh | sh

--- a/kind-setup/teardown-cluster.sh
+++ b/kind-setup/teardown-cluster.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+cd "${0%/*}"
+# Destroy cluster and delete everyting
+bash ../teardown-kubernetes-goat.sh
+kind delete clusters kubernetes-goat-cluster

--- a/scenarios/health-check/deployment-kind.yaml
+++ b/scenarios/health-check/deployment-kind.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: health-check-deployment
+spec:
+  selector:
+    matchLabels:
+      app: health-check
+  template:
+    metadata:
+      labels:
+        app: health-check
+    spec:
+      containers:
+      - name: health-check
+        image: madhuakula/k8s-goat-health-check
+        resources:
+          limits:
+            memory: "100Mi"
+            cpu: "30m"
+        ports:
+        - containerPort: 80
+      # Custom Stuff
+        securityContext:
+          privileged: true
+        volumeMounts:
+          - mountPath: /custom/docker/docker.sock
+            name: docker-sock-volume
+      volumes:
+        - name: docker-sock-volume
+          hostPath:
+            path: /var/run/docker.sock
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: health-check-service
+spec:
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 80
+  selector:
+    app: health-check


### PR DESCRIPTION
Adding kind support exposes the host docker.sock file. Thus, you will see the containers running in the host, not on the cluster node. It works for educational purposes. The idea is to use a docker socket in the host to emulate the, possibly exposed, docker socket in the node that runs on the cluster. This let us use the same attack vector as in the walkthrough for the Kubernetes GOAT. 