### PR TITLE
Adding working directory setup to bash scripts

### DIFF
--- a/setup-kubernetes-goat.sh
+++ b/setup-kubernetes-goat.sh
@@ -3,6 +3,9 @@
 # This program has been created as part of Kuberentes Goat
 # Kuberentes Goat setup and manage vulnerable infrastrcuture 
 
+# Setup working dir
+cd "${0%/*}"
+
 # Checking kubectl setup
 kubectl version --short > /dev/null 2>&1 
 if [ $? -eq 0 ];

--- a/teardown-kubernetes-goat.sh
+++ b/teardown-kubernetes-goat.sh
@@ -3,6 +3,9 @@
 # This program has been created as part of Kuberentes Goat
 # Teardown Kuberentes Goat setup
 
+# Setup working dir
+cd "${0%/*}"
+
 # Removing the helm-tiller cluster role/binding
 kubectl delete clusterrole all-your-base
 kubectl delete clusterrolebindings belong-to-us


### PR DESCRIPTION
Just adding a line to setup the working directory for the bash scripts. They were not working well with the teardown-cluster.sh script. This should not have any effect other than just set the working directory when running the script.