### PR TITLE
Fix docker-sock-volume type

### DIFF
--- a/scenarios/docker-bench-security/deployment.yaml
+++ b/scenarios/docker-bench-security/deployment.yaml
@@ -89,4 +89,4 @@ spec:
         - name: docker-sock-volume
           hostPath:
             path: /var/run/docker.sock
-            type: File
+            type: Socket

--- a/scenarios/health-check/deployment.yaml
+++ b/scenarios/health-check/deployment.yaml
@@ -30,7 +30,7 @@ spec:
         - name: docker-sock-volume
           hostPath:
             path: /var/run/docker.sock
-            type: File
+            type: Socket
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
on k8s version 1.19 this type leads to error and pods do not start

```
18m         Warning   FailedMount               pod/health-check-deployment-57c65cf5db-gbqf4            MountVolume.SetUp failed for volume "docker-sock-volume" : hostPath type check failed: /var/run/docker.sock is not a file
```