### PR TITLE
Removing the superadmin cluster role/binding

### DIFF
--- a/teardown-kubernetes-goat.sh
+++ b/teardown-kubernetes-goat.sh
@@ -3,6 +3,10 @@
 # This program has been created as part of Kuberentes Goat
 # Teardown Kuberentes Goat setup
 
+# Removing the superadmin cluster role/binding
+kubectl delete clusterrolebindings superadmin
+kubectl delete serviceaccount -n kube-system superadmin
+
 # Removing the helm-tiller cluster role/binding
 kubectl delete clusterrole all-your-base
 kubectl delete clusterrolebindings belong-to-us


### PR DESCRIPTION
This deletes the changes that were done in `scenarios/insecure-rbac/setup.yaml`
Prior to this change, if you ran setup -> teardown -> setup, you would see the following message:
```
serviceaccount/superadmin unchanged
clusterrolebinding.rbac.authorization.k8s.io/superadmin unchanged
```