### PR TITLE
Arm64 docker mods

### DIFF
--- a/infrastructure/goat-home/Dockerfile
+++ b/infrastructure/goat-home/Dockerfile
@@ -6,6 +6,11 @@ ENV HUGO_VERSION 0.84.0
 ENV HUGO_BINARY hugo_${HUGO_VERSION}_Linux-64bit.tar.gz
 RUN set -x && \
   apk add --update wget git ca-certificates imagemagick && \
+  if [ `uname -m` == "aarch64" ]; then \
+      HUGO_BINARY=hugo_${HUGO_VERSION}_Linux-ARM64.tar.gz; \
+  else \
+      HUGO_BINARY=hugo_${HUGO_VERSION}_Linux-64bit.tar.gz; \
+  fi; \
   wget https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/${HUGO_BINARY} && \
   tar xzf ${HUGO_BINARY} && \
   mv hugo /usr/bin

--- a/infrastructure/helm-tiller/Dockerfile
+++ b/infrastructure/helm-tiller/Dockerfile
@@ -6,7 +6,7 @@ ENV KUBECTL_VERSION=1.18.3
 
 WORKDIR /tmp/
 
-RUN apt update && apt install curl wget ca-certificates bash telnet -y \
+RUN apt update && apt install curl wget ca-certificates bash telnet -y && \
     if [ `uname -m` == "aarch64" ]; then \
         ARCH="arm"; \
     else \

--- a/infrastructure/helm-tiller/Dockerfile
+++ b/infrastructure/helm-tiller/Dockerfile
@@ -7,13 +7,18 @@ ENV KUBECTL_VERSION=1.18.3
 WORKDIR /tmp/
 
 RUN apt update && apt install curl wget ca-certificates bash telnet -y \
-    && curl -LO https://get.helm.sh/helm-v${HELMV2_VERSION}-linux-amd64.tar.gz \
-    && tar -zxvf helm-v${HELMV2_VERSION}-linux-amd64.tar.gz \
-    && curl -LO https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl \
+    if [ `uname -m` == "aarch64" ]; then \
+        ARCH="arm"; \
+    else \
+        ARCH="amd"; \
+    fi; \
+    && curl -LO https://get.helm.sh/helm-v${HELMV2_VERSION}-linux-${ARCH}64.tar.gz \
+    && tar -zxvf helm-v${HELMV2_VERSION}-linux-${ARCH}64.tar.gz \
+    && curl -LO https://dl.k8s.io/v${KUBECTL_VERSION}/bin/linux/${ARCH}64/kubectl \
     && mv kubectl /usr/local/bin/kubectl \
     && chmod +x /usr/local/bin/kubectl \
-    && mv linux-amd64/helm /usr/local/bin/helm \
-    && mv linux-amd64/tiller /usr/local/bin/tiller \
+    && mv linux-${ARCH}64/helm /usr/local/bin/helm \
+    && mv linux-${ARCH}64/tiller /usr/local/bin/tiller \
     && rm -rf /tmp/* /var/lib/apt/lists/*
 
 COPY pwnchart /pwnchart/

--- a/infrastructure/hunger-check/Dockerfile
+++ b/infrastructure/hunger-check/Dockerfile
@@ -2,7 +2,13 @@ FROM ubuntu:18.04
 LABEL MAINTAINER="Madhu Akula" INFO="Kubernetes Goat"
 
 RUN apt update && apt install stress-ng curl wget -y \
-    && cd /tmp; wget https://github.com/yudai/gotty/releases/download/v1.0.1/gotty_linux_amd64.tar.gz \
+    && cd /tmp; \
+    if [ `uname -m` == "aarch64" ]; then \
+        GOTTY="gottty_linux_arm.tar.gz"; \
+    else \
+        GOTTY="gotty_linux_amd64.tar.gz"; \
+    fi; \
+    wget https://github.com/yudai/gotty/releases/download/v1.0.1/$GOTTY \
     && tar -xvzf gotty_linux_amd64.tar.gz; mv gotty /usr/local/bin/gotty
 
 EXPOSE 8080

--- a/infrastructure/hunger-check/Dockerfile
+++ b/infrastructure/hunger-check/Dockerfile
@@ -4,7 +4,7 @@ LABEL MAINTAINER="Madhu Akula" INFO="Kubernetes Goat"
 RUN apt update && apt install stress-ng curl wget -y \
     && cd /tmp; \
     if [ `uname -m` == "aarch64" ]; then \
-        GOTTY="gottty_linux_arm.tar.gz"; \
+        GOTTY="gotty_linux_arm.tar.gz"; \
     else \
         GOTTY="gotty_linux_amd64.tar.gz"; \
     fi; \

--- a/infrastructure/system-monitor/Dockerfile
+++ b/infrastructure/system-monitor/Dockerfile
@@ -3,7 +3,13 @@ LABEL MAINTAINER="Madhu Akula" INFO="Kubernetes Goat"
 
 RUN apt-get update && apt-get install -y htop \
     libcap2-bin curl wget && \
-    cd /tmp; wget https://github.com/yudai/gotty/releases/download/v1.0.1/gotty_linux_amd64.tar.gz \
+    cd /tmp; \
+    if [ `uname -m` == "aarch64" ]; then \
+        GOTTY="gottty_linux_arm.tar.gz"; \
+    else \
+        GOTTY="gotty_linux_amd64.tar.gz"; \
+    fi; \
+    wget https://github.com/yudai/gotty/releases/download/v1.0.1/$GOTTY \
     && tar -xvzf gotty_linux_amd64.tar.gz; mv gotty /usr/local/bin/gotty
 
 EXPOSE 8080

--- a/infrastructure/system-monitor/Dockerfile
+++ b/infrastructure/system-monitor/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && apt-get install -y htop \
     libcap2-bin curl wget && \
     cd /tmp; \
     if [ `uname -m` == "aarch64" ]; then \
-        GOTTY="gottty_linux_arm.tar.gz"; \
+        GOTTY="gotty_linux_arm.tar.gz"; \
     else \
         GOTTY="gotty_linux_amd64.tar.gz"; \
     fi; \


### PR DESCRIPTION
Should be a good fix for two of the docker containers - as mentioned in issue #46 / #47. Still may have issues:

Goat-home (mention of linux 64 - not sure if an issue yet)
Helm tiller.