### PR TITLE
Update README.md

### DIFF
--- a/guide/README.md
+++ b/guide/README.md
@@ -46,10 +46,10 @@ To start a local environment of this project, please do the following.
 git clone https://github.com/madhuakula/kubernetes-goat.git
 ```
 
-2. Navigate to the `docs` directory
+2. Navigate to the `guide` directory
 
 ```bash
-cd docs
+cd kubernetes-goat/guide
 ```
 
 3. Install dependencies


### PR DESCRIPTION
Fix for the paths of where the guide actually is.

Additionally:

Required: 

npm audit fix 
npm install classic 

Still get the following error:
TypeError [ERR_INVALID_ARG_TYPE]: The "superCtor.prototype" property must be of type object. Received undefined
    at inherits (util.js:160:11)
    at classic (/home/pi/kubernetes-goat/guide/node_modules/classic/src/index.js:30:5)
    at /home/pi/kubernetes-goat/guide/node_modules/@docusaurus/core/lib/server/presets/index.js:35:62
    at Array.forEach (<anonymous>)
    at Object.loadPresets [as default] (/home/pi/kubernetes-goat/guide/node_modules/@docusaurus/core/lib/server/presets/index.js:22:13)
    at loadPluginConfigs (/home/pi/kubernetes-goat/guide/node_modules/@docusaurus/core/lib/server/index.js:77:79)
    at Object.load (/home/pi/kubernetes-goat/guide/node_modules/@docusaurus/core/lib/server/index.js:93:27)
    at async start (/home/pi/kubernetes-goat/guide/node_modules/@docusaurus/core/lib/commands/start.js:44:19)
error Command failed with exit code 1.
