### PR TITLE
patch `uname -m` comparison

### DIFF
--- a/infrastructure/helm-tiller/Dockerfile
+++ b/infrastructure/helm-tiller/Dockerfile
@@ -12,7 +12,7 @@ RUN apt update && apt install curl wget ca-certificates bash telnet -y; \
     else \
         ARCH="amd"; \
     fi; \
-    && curl -LO https://get.helm.sh/helm-v${HELMV2_VERSION}-linux-${ARCH}64.tar.gz \
+    curl -LO https://get.helm.sh/helm-v${HELMV2_VERSION}-linux-${ARCH}64.tar.gz \
     && tar -zxvf helm-v${HELMV2_VERSION}-linux-${ARCH}64.tar.gz \
     && curl -LO https://dl.k8s.io/v${KUBECTL_VERSION}/bin/linux/${ARCH}64/kubectl \
     && mv kubectl /usr/local/bin/kubectl \

--- a/infrastructure/helm-tiller/Dockerfile
+++ b/infrastructure/helm-tiller/Dockerfile
@@ -6,8 +6,8 @@ ENV KUBECTL_VERSION=1.18.3
 
 WORKDIR /tmp/
 
-RUN apt update && apt install curl wget ca-certificates bash telnet -y && \
-    if [ `uname -m` == "aarch64" ]; then \
+RUN apt update && apt install curl wget ca-certificates bash telnet -y; \
+    if [ `uname -m` = "aarch64" ]; then \
         ARCH="arm"; \
     else \
         ARCH="amd"; \

--- a/infrastructure/hunger-check/Dockerfile
+++ b/infrastructure/hunger-check/Dockerfile
@@ -3,7 +3,7 @@ LABEL MAINTAINER="Madhu Akula" INFO="Kubernetes Goat"
 
 RUN apt update && apt install stress-ng curl wget -y \
     && cd /tmp; \
-    if [ `uname -m` == "aarch64" ]; then \
+    if [ `uname -m` = "aarch64" ]; then \
         GOTTY="gotty_linux_arm.tar.gz"; \
     else \
         GOTTY="gotty_linux_amd64.tar.gz"; \

--- a/infrastructure/system-monitor/Dockerfile
+++ b/infrastructure/system-monitor/Dockerfile
@@ -4,7 +4,7 @@ LABEL MAINTAINER="Madhu Akula" INFO="Kubernetes Goat"
 RUN apt-get update && apt-get install -y htop \
     libcap2-bin curl wget && \
     cd /tmp; \
-    if [ `uname -m` == "aarch64" ]; then \
+    if [ `uname -m` = "aarch64" ]; then \
         GOTTY="gotty_linux_arm.tar.gz"; \
     else \
         GOTTY="gotty_linux_amd64.tar.gz"; \


### PR DESCRIPTION
Contrary to common programming practices, the comparison operator needs to be a single `=` here.
Otherwise, this script is executed by /bin/sh (not /bin/bash) and the following error occurs:
`/bin/sh: 1: [: aarch64: unexpected operator`

Currently my arm64 system still downloads the amd64 version of gotty.

EDIT: Fixed the error message. I was playing around with wrapping in double square brackets `[[ ]]` and the `==` operator. The proper error message is the "unexpected operator" one listed above.