### PR TITLE
Added K3s guidance for installing docker container runtime

### DIFF
--- a/guide/docs/how-to-run/k3s.md
+++ b/guide/docs/how-to-run/k3s.md
@@ -5,3 +5,22 @@ sidebar_label: ☸️ K3S
 # ☸️ K3S - Legithwegith Kubernetes
 
 **TBD: WORK IN PROGRESS**
+
+The docker container runtime must be used to complete some of the included scenarios. K3s uses containerd by default, so adding docker support requires the following steps during installation:
+
+```bash
+# Ensure docker version is up-to-date. Reference this repo: https://github.com/rancher/install-docker
+curl https://releases.rancher.com/install-docker/20.10.sh | sh
+# Change cgroup to cgroupfs because k3s does not use systemd cgroup
+echo -e '{\n  "exec-opts": ["native.cgroupdriver=cgroupfs"]\n}' | sudo tee /etc/docker/daemon.json
+sudo systemctl daemon-reload
+sudo systemctl restart docker
+# Install k3s on server with docker option
+curl -sfL https://get.k3s.io | sh -s server --docker
+SERVER_NAME=$(hostname)  # or enter your local IP address
+NODE_TOKEN=$(cat /var/lib/rancher/k3s/server/node-token)
+# Install k3s on agent with docker option
+curl -sfL https://get.k3s.io | K3S_URL=https://${SERVER_NAME}:6443 K3S_TOKEN=${NODE_TOKEN} sh -s agent --docker
+```
+
+Keep in mind that your system architecture affects the scenarios (e.g., you will need to download a different docker binary to complete the docker-in-docker scenario).


### PR DESCRIPTION
I added some content to the K3s page to assist with setup:

- docker is needed for some of the scenarios, so I have added instructions for installing. The K3s default is containerd.
- docker uses systemd cgroup by default, but K3s does not support it due to [dependencies on statically-linked binaries](https://github.com/k3s-io/k3s/issues/797#issuecomment-529139150).