### PR TITLE
Adding system architecture check to scenario 2 guide

### DIFF
--- a/guide/docs/scenarios/scenario-2.md
+++ b/guide/docs/scenarios/scenario-2.md
@@ -80,7 +80,13 @@ We can use multiple methods for communicating with the `docker.sock` UNIX socket
 
 :::
 
-* We can download the official `docker` static binary from the internet [https://download.docker.com/linux/static/stable/](https://download.docker.com/linux/static/stable/) to the container using the following command 
+* Next we can download the official `docker` static binary from the internet [https://download.docker.com/linux/static/stable/](https://download.docker.com/linux/static/stable/). In order to determine which binary we need, we can run the following command for system discovery
+
+```bash
+;uname -a
+```
+
+* We can examine the output to determine our system architecture and OS, then download the appropriate docker binary to the container. For example, if our target system is a x86\_64 Linux box, we can use the following command
 
 ```bash
 ;wget https://download.docker.com/linux/static/stable/x86_64/docker-19.03.9.tgz -O /tmp/docker-19.03.9.tgz


### PR DESCRIPTION
Added additional step to mention running `uname -a` and downloading appropriate docker binary for the target machine's system architecture.