### PR TITLE
Change Content-Type suggestion

### DIFF
--- a/infrastructure/internal-api/code/index.html
+++ b/infrastructure/internal-api/code/index.html
@@ -41,7 +41,7 @@
                 <p class="font-semibold">Custom Header: </p><br>
                 <input
                     class="bg-white focus:outline-none focus:shadow-outline border border-gray-300 rounded-lg py-2 px-4 block w-full appearance-none leading-normal header"
-                    type="text" placeholder="{ 'Content-Type': 'application/json' }" id="headers"><br><br>
+                    type="text" placeholder="Content-Type: application/json" id="headers"><br><br>
 
                 <button
                     class="bg-transparent hover:bg-blue-500 text-blue-700 font-semibold hover:text-white py-2 px-4 border border-blue-500 hover:border-transparent rounded submit-button"


### PR DESCRIPTION
Using `{'Content-Type': 'application/json'}` will result in "400 Bad Request: invalid header name" response.


Additionally, I noticed there was some confusion like this issue: https://github.com/madhuakula/kubernetes-goat/issues/81 and [this discord post](https://discord.com/channels/976503864268308580/976584365817618462/1014366224613908500). In both scenarios a user submitted a screenshot where the Custom Header field is empty. It was not an issue with Kubernetes Goat, but maybe we can clear up the confusion by auto-filling fields or adding additional instructions to the scenario hints.

<br/>

I see that you're using `HACKTOBERFEST-ACCEPTED` label so feel free to do that to this PR too.