### PR TITLE
Duct tape fix for broken gotty arm binary

### DIFF
--- a/infrastructure/system-monitor/Dockerfile
+++ b/infrastructure/system-monitor/Dockerfile
@@ -5,11 +5,11 @@ RUN apt-get update && apt-get install -y htop \
     libcap2-bin curl wget && \
     cd /tmp; \
     if [ `uname -m` = "aarch64" ]; then \
-        GOTTY="gotty_linux_arm.tar.gz"; \
+        GOTTY="gotty_2.0.0-alpha.3_linux_arm.tar.gz"; \
     else \
-        GOTTY="gotty_linux_amd64.tar.gz"; \
+        GOTTY="gotty_2.0.0-alpha.3_linux_amd64.tar.gz"; \
     fi; \
-    wget https://github.com/yudai/gotty/releases/download/v1.0.1/${GOTTY} \
+    wget https://github.com/yudai/gotty/releases/download/v2.0.0-alpha.3/${GOTTY} \
     && tar -xvzf ${GOTTY}; mv gotty /usr/local/bin/gotty
 
 EXPOSE 8080


### PR DESCRIPTION
For some reason gotty 1.01's distribution binary for arm (in the repo) is busted, causing it to break on ARM-based macs.  Rather than have it build itself manually, I switched to the 2.0 alpha branch and it seems to work well enough.