### PR TITLE
make setup-kubernetes-goat.sh executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@
 ```bash
 git clone https://github.com/madhuakula/kubernetes-goat.git
 cd kubernetes-goat
+chmod +x setup-kubernetes-goat.sh
 bash setup-kubernetes-goat.sh
 ```
 


### PR DESCRIPTION
making setup-kubernetes-goat.sh file executable to pass `Error: Could not find kubectl or an other error happend, please check kubectl setup.`