### PR TITLE
Adding Kubescape GitHub action to show security problems and misconfigurations in the GitHub Security tab

### DIFF
--- a/.github/workflows/example-yaml-scanning.yaml
+++ b/.github/workflows/example-yaml-scanning.yaml
@@ -1,0 +1,16 @@
+name: Kubescape scanning for misconfigurations
+on: [push, pull_request]
+jobs:
+  kubescape-scan:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: kubescape/github-action@main
+      continue-on-error: true
+      with:
+        format: sarif
+        outputFile: results.sarif
+    - name: Upload Kubescape scan results to Github Code Scanning
+      uses: github/codeql-action/upload-sarif@v2
+      with:
+        sarif_file: results.sarif

--- a/.github/workflows/example-yaml-scanning.yaml
+++ b/.github/workflows/example-yaml-scanning.yaml
@@ -6,6 +6,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: kubescape/github-action@main
+      framework: AllControls
       continue-on-error: true
       with:
         format: sarif


### PR DESCRIPTION
Added a workflow that will populate the security/code-issues screen (tab in the repo), this will enable demonstrating part of the issues in GitHub (without even cluster).

Here is an example https://github.com/kubescape/github-action/security/code-scanning/313