### PR TITLE
Support for Arm based Mac's - prevents system monitor (gotty) crash

### DIFF
--- a/infrastructure/system-monitor/Dockerfile
+++ b/infrastructure/system-monitor/Dockerfile
@@ -4,7 +4,8 @@ LABEL MAINTAINER="Madhu Akula" INFO="Kubernetes Goat"
 RUN apt-get update && apt-get install -y htop \
     libcap2-bin curl wget && \
     cd /tmp; \
-    if [ `uname -m` = "aarch64" ]; then \
+    arch=`uname -m` && \
+    if [ $arch = "aarch64" ] || [ $arch = "arm64" ]; then \
         GOTTY="gotty_2.0.0-alpha.3_linux_arm.tar.gz"; \
     else \
         GOTTY="gotty_2.0.0-alpha.3_linux_amd64.tar.gz"; \


### PR DESCRIPTION
System-monitor would fall into a crash loop due to invalid gotty architecture download and install.

<img width="885" alt="Screenshot 2023-04-27 at 11 08 33 PM" src="https://user-images.githubusercontent.com/75212845/234977607-f5fbd4a7-f44d-4ea0-b785-8d82983a157f.png">
<img width="766" alt="Screenshot 2023-04-28 at 1 32 45 AM" src="https://user-images.githubusercontent.com/75212845/234978181-14778696-4268-41dc-bd78-ffadf2d953c8.png">
