### PR TITLE
Support for Arm based Mac's - prevents hunger check (gotty) crash

### DIFF
--- a/infrastructure/hunger-check/Dockerfile
+++ b/infrastructure/hunger-check/Dockerfile
@@ -3,12 +3,13 @@ LABEL MAINTAINER="Madhu Akula" INFO="Kubernetes Goat"
 
 RUN apt update && apt install stress-ng curl wget -y \
     && cd /tmp; \
-    if [ `uname -m` = "aarch64" ]; then \
-        GOTTY="gotty_linux_arm.tar.gz"; \
+    arch=`uname -m` && \
+    if [ $arch = "aarch64" ] || [ $arch = "arm64" ]; then \
+        GOTTY="gotty_2.0.0-alpha.3_linux_arm.tar.gz"; \
     else \
-        GOTTY="gotty_linux_amd64.tar.gz"; \
+        GOTTY="gotty_2.0.0-alpha.3_linux_amd64.tar.gz"; \
     fi; \
-    wget https://github.com/yudai/gotty/releases/download/v1.0.1/${GOTTY} \
+    wget https://github.com/yudai/gotty/releases/download/v2.0.0-alpha.3/${GOTTY} \
     && tar -xvzf ${GOTTY}; mv gotty /usr/local/bin/gotty
 
 EXPOSE 8080


### PR DESCRIPTION
https://github.com/madhuakula/kubernetes-goat/issues/115

Just saw the open issue and noticed that the hunger-check Dockerfile needed the same fix
Please merge and update this image as well
