### PR TITLE
Include namespace for all necessary fields

### DIFF
--- a/scenarios/build-code/deployment.yaml
+++ b/scenarios/build-code/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: build-code-deployment
+  namespace: default
 spec:
   selector:
     matchLabels:
@@ -25,6 +26,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: build-code-service
+  namespace: default
 spec:
   ports:
   - protocol: TCP

--- a/scenarios/health-check/deployment-kind.yaml
+++ b/scenarios/health-check/deployment-kind.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: health-check-deployment
+  namespace: default
 spec:
   selector:
     matchLabels:
@@ -35,6 +36,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: health-check-service
+  namespace: default
 spec:
   ports:
   - protocol: TCP

--- a/scenarios/internal-proxy/deployment.yaml
+++ b/scenarios/internal-proxy/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: internal-proxy-deployment
+  namespace: default
   labels:
     app: internal-proxy
 spec:
@@ -41,6 +42,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: internal-proxy-api-service
+  namespace: default
 spec:
   ports:
   - protocol: TCP
@@ -53,6 +55,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: internal-proxy-info-app-service
+  namespace: default
 spec:
   type: NodePort
   ports:

--- a/scenarios/kubernetes-goat-home/deployment.yaml
+++ b/scenarios/kubernetes-goat-home/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kubernetes-goat-home-deployment
+  namespace: default
 spec:
   selector:
     matchLabels:
@@ -25,6 +26,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: kubernetes-goat-home-service
+  namespace: default
 spec:
   ports:
   - protocol: TCP

--- a/scenarios/poor-registry/deployment.yaml
+++ b/scenarios/poor-registry/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: poor-registry-deployment
+  namespace: default
 spec:
   selector:
     matchLabels:
@@ -25,6 +26,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: poor-registry-service
+  namespace: default
 spec:
   ports:
   - protocol: TCP

--- a/scenarios/system-monitor/deployment.yaml
+++ b/scenarios/system-monitor/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: goatvault
+  namespace: default
 type: Opaque
 data:
   k8sgoatvaultkey: azhzLWdvYXQtY2QyZGEyNzIyNDU5MWRhMmI0OGVmODM4MjZhOGE2YzM=
@@ -11,6 +12,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: system-monitor-deployment
+  namespace: default
 spec:
   selector:
     matchLabels:
@@ -53,6 +55,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: system-monitor-service
+  namespace: default
 spec:
   ports:
   - protocol: TCP


### PR DESCRIPTION
In the [access-kubernetes-goat.sh](https://github.com/madhuakula/kubernetes-goat/blob/master/access-kubernetes-goat.sh), the services are being exposed from the default namespace.

If the user runs the [setup-kubernetes-goat.sh](https://github.com/madhuakula/kubernetes-goat/blob/master/setup-kubernetes-goat.sh) from any other namespace, the resources will be created in them & [access-kubernetes-goat.sh](https://github.com/madhuakula/kubernetes-goat/blob/master/access-kubernetes-goat.sh) won't be able to find anything in default namespace.

This PR fixes that bug by specifying the namespace for all resources that are being port-forwarded by the services.

![image](https://github.com/madhuakula/kubernetes-goat/assets/22347290/1e30026f-df42-4696-a1f9-dec30b6bcfdb)
