### PR TITLE
Scenario 2: DIND exploitation: Update deployment.yaml

### DIFF
--- a/scenarios/health-check/deployment.yaml
+++ b/scenarios/health-check/deployment.yaml
@@ -29,7 +29,7 @@ spec:
       volumes:
         - name: containerd-sock-volume
           hostPath:
-            path: /run/containerd/containerd.sock
+            path: /run/docker.sock
             type: Socket
 ---
 apiVersion: v1


### PR DESCRIPTION
Im using the Minikube. When i tried to access the host’s container runtime, with Containerd, ctr and docker i got an empty table or different errors which ended to be rabit holes. 

The installed different Docker-Binaries to get an Workaround and saw that docker usese the Domain-Unix-Socket /run/docker.sock when starting dockerd.
So I changed the Unix-domain-socket in the deployment.yaml from /run/containerd/containerd.sock to /run/docker.sock and it worked. Otherwise i did not get access to the host's container runtime environment.

I suspect that Kubernetes is using the Unix-socket containerd.sock and this is causing problems. I'll investigate the behavior more closely as soon as I have more time.

Works for the Minikube
I am not aware of the impact it would have on other deployments.
