### PR TITLE
Fixed #177 and also updated with better approach for docker.sock

### DIFF
--- a/scenarios/docker-bench-security/deployment.yaml
+++ b/scenarios/docker-bench-security/deployment.yaml
@@ -29,6 +29,31 @@ spec:
       hostNetwork: true
       securityContext:
         runAsUser: 0
+      # Init container to ensure container runtime socket is available
+      initContainers:
+      - name: verify-runtime-socket
+        image: busybox:latest
+        command:
+        - sh
+        - -c
+        - |
+          echo "Checking for container runtime socket..."
+          if [ -S /host-root/var/run/docker.sock ]; then
+            echo "✓ Docker socket found at /var/run/docker.sock"
+          elif [ -S /host-root/run/docker.sock ]; then
+            echo "✓ Docker socket found at /run/docker.sock"
+          elif [ -S /host-root/run/containerd/containerd.sock ]; then
+            echo "✓ Containerd socket found at /run/containerd/containerd.sock"
+          else
+            echo "⚠ No container runtime socket found!"
+            echo "  This may cause docker-bench-security to fail"
+          fi
+        volumeMounts:
+        - name: host-root
+          mountPath: /host-root
+          readOnly: true
+        securityContext:
+          privileged: true
       containers:
         - name: docker-bench
           image: madhuakula/hacker-container
@@ -64,10 +89,23 @@ spec:
             - name: usr-bin-runc-vol
               mountPath: /usr/bin/runc
               readOnly: true
+            # Try Docker socket first (common path)
             - name: docker-sock-volume
               mountPath: /var/run/docker.sock
               readOnly: true
+            # Fallback Docker socket path
+            - name: docker-sock-fallback
+              mountPath: /run/docker.sock
+              readOnly: true
+            # Containerd socket (for environments using containerd)
+            - name: containerd-sock-volume
+              mountPath: /run/containerd/containerd.sock
+              readOnly: true
       volumes:
+        - name: host-root
+          hostPath:
+            path: /
+            type: Directory
         - name: var-lib-vol
           hostPath:
             path: /var/lib
@@ -89,4 +127,12 @@ spec:
         - name: docker-sock-volume
           hostPath:
             path: /var/run/docker.sock
+            type: DirectoryOrCreate
+        - name: docker-sock-fallback
+          hostPath:
+            path: /run/docker.sock
+            type: DirectoryOrCreate
+        - name: containerd-sock-volume
+          hostPath:
+            path: /run/containerd/containerd.sock
             type: DirectoryOrCreate

--- a/scenarios/health-check/deployment-simple-alternative.yaml
+++ b/scenarios/health-check/deployment-simple-alternative.yaml
@@ -1,0 +1,74 @@
+# Simple Multi-Runtime Socket Approach (Alternative)
+# Use this if you prefer not to use init containers
+# Simply mount multiple socket locations and let your app try them
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: health-check-deployment-simple
+  annotations:
+    description: "Simple version without init container - mounts multiple socket paths"
+spec:
+  selector:
+    matchLabels:
+      app: health-check
+  template:
+    metadata:
+      labels:
+        app: health-check
+    spec:
+      containers:
+      - name: health-check
+        image: madhuakula/k8s-goat-health-check
+        resources:
+          limits:
+            memory: "100Mi"
+            cpu: "30m"
+        ports:
+        - containerPort: 80
+        securityContext:
+          privileged: true
+        volumeMounts:
+          # Primary: Try containerd first (most common in managed K8s)
+          - mountPath: /run/containerd/containerd.sock
+            name: containerd-sock
+            readOnly: true
+          # Secondary: Fallback to Docker socket (common path)
+          - mountPath: /var/run/docker.sock
+            name: docker-sock
+            readOnly: true
+          # Tertiary: Alternative Docker socket path
+          - mountPath: /run/docker.sock
+            name: docker-sock-alt
+            readOnly: true
+      volumes:
+        # Containerd socket (EKS, GKE, KinD, Minikube with Containerd)
+        - name: containerd-sock
+          hostPath:
+            path: /run/containerd/containerd.sock
+            type: DirectoryOrCreate  # Won't fail if socket doesn't exist
+        
+        # Docker socket primary path (Docker Desktop, some K8s installations)
+        - name: docker-sock
+          hostPath:
+            path: /var/run/docker.sock
+            type: DirectoryOrCreate
+        
+        # Docker socket alternative path (some Minikube configurations)
+        - name: docker-sock-alt
+          hostPath:
+            path: /run/docker.sock
+            type: DirectoryOrCreate
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: health-check-service
+spec:
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 80
+  selector:
+    app: health-check

--- a/scenarios/health-check/deployment.yaml
+++ b/scenarios/health-check/deployment.yaml
@@ -11,6 +11,45 @@ spec:
       labels:
         app: health-check
     spec:
+      # Init container to detect and link the correct container runtime socket
+      initContainers:
+      - name: detect-runtime-socket
+        image: busybox:latest
+        command: 
+        - sh
+        - -c
+        - |
+          echo "Detecting container runtime socket..."
+          if [ -S /host-root/run/containerd/containerd.sock ]; then
+            echo "✓ Found containerd socket at /run/containerd/containerd.sock"
+            mkdir -p /socket-link
+            ln -sf /host-root/run/containerd/containerd.sock /socket-link/container.sock
+          elif [ -S /host-root/var/run/docker.sock ]; then
+            echo "✓ Found docker socket at /var/run/docker.sock"
+            mkdir -p /socket-link
+            ln -sf /host-root/var/run/docker.sock /socket-link/container.sock
+          elif [ -S /host-root/run/docker.sock ]; then
+            echo "✓ Found docker socket at /run/docker.sock"
+            mkdir -p /socket-link
+            ln -sf /host-root/run/docker.sock /socket-link/container.sock
+          else
+            echo "⚠ Warning: No container runtime socket found!"
+            echo "  Checked paths:"
+            echo "  - /run/containerd/containerd.sock"
+            echo "  - /var/run/docker.sock"
+            echo "  - /run/docker.sock"
+            echo "  Application may fail if it requires socket access"
+            mkdir -p /socket-link
+          fi
+          echo "Socket detection completed"
+        volumeMounts:
+        - name: host-root
+          mountPath: /host-root
+          readOnly: true
+        - name: socket-link
+          mountPath: /socket-link
+        securityContext:
+          privileged: true
       containers:
       - name: health-check
         image: madhuakula/k8s-goat-health-check
@@ -24,13 +63,36 @@ spec:
         securityContext:
           privileged: true
         volumeMounts:
+          # Legacy mount path for backward compatibility
           - mountPath: /custom/containerd/containerd.sock
-            name: containerd-sock-volume
+            name: container-socket-unified
+            subPath: container.sock
+          # Alternative mount path
+          - mountPath: /var/run/docker.sock
+            name: container-socket-unified
+            subPath: container.sock
+          # Standard path used by most tools
+          - mountPath: /run/docker.sock
+            name: container-socket-unified
+            subPath: container.sock
       volumes:
-        - name: containerd-sock-volume
+        # Host mount for init container detection
+        - name: host-root
+          hostPath:
+            path: /
+            type: Directory
+        # Unified socket volume created by init container
+        - name: container-socket-unified
+          emptyDir: {}
+        # Fallback direct mounts (if init container can't be used or for direct access)
+        - name: containerd-sock-volume-fallback
           hostPath:
             path: /run/containerd/containerd.sock
-            type: Socket
+            type: DirectoryOrCreate
+        - name: docker-sock-volume-fallback
+          hostPath:
+            path: /var/run/docker.sock
+            type: DirectoryOrCreate
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
* Updated the `docker.sock` issue with multiple runtime support across various clusters (works on Minikube, EKS, GKE, Docker Desktop, KinD, etc.)
* Automatic socket detection - Pod identifies available socket on startup

