### PR TITLE
Add missing volume definition to health-check deployment

### DIFF
--- a/scenarios/health-check/deployment.yaml
+++ b/scenarios/health-check/deployment.yaml
@@ -81,6 +81,9 @@ spec:
           hostPath:
             path: /
             type: Directory
+        # Symlinks to the host systems container management sockets
+        - name: socket-link
+          emptyDir: {}
         # Unified socket volume created by init container
         - name: container-socket-unified
           emptyDir: {}


### PR DESCRIPTION
When trying to start up kubernetes-goat's scenario 'health-check', the following error occurs because the volume `socket-link` is not defined.
```bash
$> kubectl apply -f scenarios/health-check/deployment.yaml
service/health-check-service unchanged
The Deployment "health-check-deployment" is invalid: spec.template.spec.initContainers[0].volumeMounts[1].name: Not found: "socket-link"
```

This PR adds that volume definition.

```yaml
volumes:
    - name: socket-link
      emptyDir: {}
```

I would like to add that I have only tested this setup on my own system with a docker socket located at `/run/docker.sock`.
